### PR TITLE
cpu and memory optimization

### DIFF
--- a/src/main/java/com/jyuzawa/onnxruntime/ApiImpl.java
+++ b/src/main/java/com/jyuzawa/onnxruntime/ApiImpl.java
@@ -102,6 +102,7 @@ import java.lang.foreign.Addressable;
 import java.lang.foreign.MemoryAddress;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySession;
+import java.lang.foreign.SegmentAllocator;
 import java.util.function.Function;
 
 final class ApiImpl implements Api {
@@ -306,19 +307,19 @@ final class ApiImpl implements Api {
         throw new OnnxRuntimeException(code, message);
     }
 
-    MemoryAddress create(MemorySession allocator, Function<MemoryAddress, Addressable> constructor) {
+    MemoryAddress create(SegmentAllocator allocator, Function<MemoryAddress, Addressable> constructor) {
         MemorySegment pointer = allocator.allocate(C_POINTER);
         checkStatus(constructor.apply(pointer.address()));
         return pointer.getAtIndex(C_POINTER, 0);
     }
 
-    int extractInt(MemorySession allocator, Function<MemoryAddress, Addressable> method) {
+    int extractInt(SegmentAllocator allocator, Function<MemoryAddress, Addressable> method) {
         MemorySegment pointer = allocator.allocate(C_INT);
         checkStatus(method.apply(pointer.address()));
         return pointer.getAtIndex(C_INT, 0);
     }
 
-    long extractLong(MemorySession allocator, Function<MemoryAddress, Addressable> method) {
+    long extractLong(SegmentAllocator allocator, Function<MemoryAddress, Addressable> method) {
         MemorySegment pointer = allocator.allocate(C_LONG);
         checkStatus(method.apply(pointer.address()));
         return pointer.getAtIndex(C_LONG, 0);

--- a/src/main/java/com/jyuzawa/onnxruntime/OnnxOpaqueImpl.java
+++ b/src/main/java/com/jyuzawa/onnxruntime/OnnxOpaqueImpl.java
@@ -6,6 +6,7 @@ package com.jyuzawa.onnxruntime;
 
 import java.lang.foreign.MemoryAddress;
 import java.lang.foreign.MemorySession;
+import java.lang.foreign.SegmentAllocator;
 import java.nio.ByteBuffer;
 
 final class OnnxOpaqueImpl extends OnnxValueImpl implements OnnxOpaque {
@@ -18,10 +19,10 @@ final class OnnxOpaqueImpl extends OnnxValueImpl implements OnnxOpaque {
         this.opaqueInfo = opaqueInfo;
     }
 
-    //    @Override
-    //    public OnnxOpaque asOpaque() {
-    //        return this;
-    //    }
+    // @Override
+    // public OnnxOpaque asOpaque() {
+    // return this;
+    // }
 
     @Override
     public OpaqueInfo getInfo() {
@@ -35,13 +36,18 @@ final class OnnxOpaqueImpl extends OnnxValueImpl implements OnnxOpaque {
 
     @Override
     public MemoryAddress toNative(
-            ApiImpl api, MemoryAddress ortAllocator, MemoryAddress memoryInfo, MemorySession allocator) {
+            ApiImpl api, MemoryAddress ortAllocator, MemoryAddress memoryInfo, SegmentAllocator allocator) {
         // TODO Auto-generated method stub
         return null;
     }
 
     @Override
-    public void fromNative(ApiImpl api, MemoryAddress ortAllocator, MemoryAddress address, MemorySession allocator) {
+    public void fromNative(
+            ApiImpl api,
+            MemoryAddress ortAllocator,
+            MemoryAddress address,
+            SegmentAllocator allocator,
+            MemorySession session) {
         // TODO Auto-generated method stub
 
     }

--- a/src/main/java/com/jyuzawa/onnxruntime/OnnxOptionalImpl.java
+++ b/src/main/java/com/jyuzawa/onnxruntime/OnnxOptionalImpl.java
@@ -6,6 +6,7 @@ package com.jyuzawa.onnxruntime;
 
 import java.lang.foreign.MemoryAddress;
 import java.lang.foreign.MemorySession;
+import java.lang.foreign.SegmentAllocator;
 import java.util.NoSuchElementException;
 
 final class OnnxOptionalImpl extends OnnxValueImpl implements OnnxOptional {
@@ -55,13 +56,18 @@ final class OnnxOptionalImpl extends OnnxValueImpl implements OnnxOptional {
 
     @Override
     public MemoryAddress toNative(
-            ApiImpl api, MemoryAddress ortAllocator, MemoryAddress memoryInfo, MemorySession allocator) {
+            ApiImpl api, MemoryAddress ortAllocator, MemoryAddress memoryInfo, SegmentAllocator allocator) {
         // TODO Auto-generated method stub
         return null;
     }
 
     @Override
-    public void fromNative(ApiImpl api, MemoryAddress ortAllocator, MemoryAddress address, MemorySession allocator) {
+    public void fromNative(
+            ApiImpl api,
+            MemoryAddress ortAllocator,
+            MemoryAddress address,
+            SegmentAllocator allocator,
+            MemorySession session) {
         // TODO Auto-generated method stub
 
     }

--- a/src/main/java/com/jyuzawa/onnxruntime/OnnxValueImpl.java
+++ b/src/main/java/com/jyuzawa/onnxruntime/OnnxValueImpl.java
@@ -6,6 +6,7 @@ package com.jyuzawa.onnxruntime;
 
 import java.lang.foreign.MemoryAddress;
 import java.lang.foreign.MemorySession;
+import java.lang.foreign.SegmentAllocator;
 import java.util.NoSuchElementException;
 
 abstract class OnnxValueImpl implements OnnxValue {
@@ -52,9 +53,14 @@ abstract class OnnxValueImpl implements OnnxValue {
     // }
 
     abstract MemoryAddress toNative(
-            ApiImpl api, MemoryAddress ortAllocator, MemoryAddress memoryInfo, MemorySession scope);
+            ApiImpl api, MemoryAddress ortAllocator, MemoryAddress memoryInfo, SegmentAllocator allocator);
 
-    abstract void fromNative(ApiImpl api, MemoryAddress ortAllocator, MemoryAddress address, MemorySession scope);
+    abstract void fromNative(
+            ApiImpl api,
+            MemoryAddress ortAllocator,
+            MemoryAddress address,
+            SegmentAllocator allocator,
+            MemorySession session);
 
     static final OnnxValueImpl fromTypeInfo(TypeInfoImpl typeInfo) {
         OnnxType type = typeInfo.getType();

--- a/src/main/java/com/jyuzawa/onnxruntime/TensorInfoImpl.java
+++ b/src/main/java/com/jyuzawa/onnxruntime/TensorInfoImpl.java
@@ -7,7 +7,7 @@ package com.jyuzawa.onnxruntime;
 import static com.jyuzawa.onnxruntime_extern.onnxruntime_all_h.C_LONG;
 
 import java.lang.foreign.MemorySegment;
-import java.lang.foreign.MemorySession;
+import java.lang.foreign.SegmentAllocator;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -31,7 +31,7 @@ final class TensorInfoImpl implements TensorInfo {
         this.elementCount = elementCount;
     }
 
-    static TensorInfoImpl of(OnnxTensorElementDataType type, long elementCount, MemorySession scope) {
+    static TensorInfoImpl of(OnnxTensorElementDataType type, long elementCount, SegmentAllocator scope) {
         MemorySegment shapeData = scope.allocateArray(C_LONG, new long[] {elementCount});
         return new TensorInfoImpl(type, shapeData, 1, elementCount);
     }

--- a/src/main/java/com/jyuzawa/onnxruntime/TransactionBuilderImpl.java
+++ b/src/main/java/com/jyuzawa/onnxruntime/TransactionBuilderImpl.java
@@ -4,12 +4,9 @@
  */
 package com.jyuzawa.onnxruntime;
 
-import static com.jyuzawa.onnxruntime_extern.onnxruntime_all_h.C_POINTER;
-
 import com.jyuzawa.onnxruntime.Transaction.Builder;
 import java.lang.foreign.MemoryAddress;
-import java.lang.foreign.MemorySegment;
-import java.lang.foreign.MemorySession;
+import java.lang.foreign.SegmentAllocator;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -112,9 +109,8 @@ final class TransactionBuilderImpl implements Transaction.Builder {
         return this;
     }
 
-    MemoryAddress newRunOptions(MemorySession scope, MemorySegment memorySegment) {
-        api.checkStatus(api.CreateRunOptions.apply(memorySegment.address()));
-        MemoryAddress runOptions = memorySegment.getAtIndex(C_POINTER, 0);
+    MemoryAddress newRunOptions(SegmentAllocator scope) {
+        MemoryAddress runOptions = api.create(scope, out -> api.CreateRunOptions.apply(out));
         if (logSeverityLevel != null) {
             api.checkStatus(api.RunOptionsSetRunLogSeverityLevel.apply(runOptions, logSeverityLevel.getNumber()));
         }

--- a/src/main/java/com/jyuzawa/onnxruntime/TransactionBuilderImpl.java
+++ b/src/main/java/com/jyuzawa/onnxruntime/TransactionBuilderImpl.java
@@ -42,8 +42,8 @@ final class TransactionBuilderImpl implements Transaction.Builder {
         this.ortAllocator = ortAllocator;
         this.allInputs = allInputs;
         this.allOutputs = allOutputs;
-        this.inputs = new ArrayList<>(1);
-        this.outputs = new ArrayList<>(1);
+        this.inputs = new ArrayList<>(allInputs.size());
+        this.outputs = new ArrayList<>(allOutputs.size());
     }
 
     @Override


### PR DESCRIPTION
* use a arena SegmentAllocator to avoid hitting malloc too often
* presize builder input outputs
* hoist OrtValue release to TransactionImpl