### PR TITLE
Prevent version mismatch segfaults

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -351,6 +351,7 @@ tasks.named('compileJava') {
 
 
 test {
+	useJUnitPlatform()
 	jvmArgs '--enable-preview', '--enable-native-access=ALL-UNNAMED'
 	finalizedBy jacocoTestReport
 }

--- a/src/main/java/com/jyuzawa/onnxruntime/Loader.java
+++ b/src/main/java/com/jyuzawa/onnxruntime/Loader.java
@@ -55,7 +55,9 @@ final class Loader {
                 System.load(libraryPath);
             }
         } catch (IOException e) {
-            throw new UnsatisfiedLinkError("Failed to load onnxruntime");
+            UnsatisfiedLinkError ule = new UnsatisfiedLinkError("Failed to load onnxruntime");
+            e.initCause(e);
+            throw ule;
         }
     }
 

--- a/src/test/java/com/jyuzawa/onnxruntime/SessionTest.java
+++ b/src/test/java/com/jyuzawa/onnxruntime/SessionTest.java
@@ -1033,6 +1033,7 @@ public class SessionTest {
             String message = e.getMessage();
             LOG.log(Level.ERROR, "Provider failed with: " + message);
             assertTrue(message.contains("not enabled in this build")
+                    || message.contains("not supported in this build")
                     || message.contains("onnxruntime::ProviderSharedLibrary")
                     || message.contains("onnxruntime::ProviderLibrary"));
         }


### PR DESCRIPTION
# Description of Changes

- using an older version would cause a segfault, so lets throw an error instead.