### PR TITLE
Add publication of snapshots to local repo

### DIFF
--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -1,0 +1,132 @@
+name: Publish Snapshots
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: gradle/actions/wrapper-validation@v5
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          distribution: oracle
+          java-version: 25
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+      - name: Get library version
+        id: version
+        run: |
+          ORT_VERSION=$(grep 'com.jyuzawa.onnxruntime.library_version' gradle.properties | cut -d'=' -f2)
+          echo "ort_version=${ORT_VERSION}" >> $GITHUB_OUTPUT
+      - name: Check if CPU artifacts exist
+        id: check_cpu
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set +e  # Don't exit on error
+          VERSION="${{ steps.version.outputs.ort_version }}"
+          OWNER="${{ github.repository_owner }}"
+          # URL-encode the package name (dots become %2E)
+          PACKAGE_NAME="com.jyuzawa.onnxruntime-cpu"
+          PACKAGE_NAME_ENCODED=$(echo "$PACKAGE_NAME" | sed 's/\./%2E/g')
+          
+          echo "Checking for package: ${PACKAGE_NAME} (encoded: ${PACKAGE_NAME_ENCODED}) version: ${VERSION} owner: ${OWNER}"
+          
+          # Try org endpoint first
+          echo "Trying org endpoint..."
+          VERSIONS=$(gh api "/orgs/${OWNER}/packages/maven/${PACKAGE_NAME_ENCODED}/versions" --jq ".[].name" 2>&1)
+          ORG_EXIT_CODE=$?
+          echo "Org endpoint result (exit code ${ORG_EXIT_CODE}): ${VERSIONS}"
+          
+          if [ $ORG_EXIT_CODE -eq 0 ] && echo "$VERSIONS" | grep -qx "${VERSION}"; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "CPU artifacts already exist (version ${VERSION}), will skip publishing"
+            exit 0
+          fi
+          
+          # Try user endpoint
+          echo "Trying user endpoint..."
+          VERSIONS=$(gh api "/users/${OWNER}/packages/maven/${PACKAGE_NAME_ENCODED}/versions" --jq ".[].name" 2>&1)
+          USER_EXIT_CODE=$?
+          echo "User endpoint result (exit code ${USER_EXIT_CODE}): ${VERSIONS}"
+          
+          if [ $USER_EXIT_CODE -eq 0 ] && echo "$VERSIONS" | grep -qx "${VERSION}"; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "CPU artifacts already exist (version ${VERSION}), will skip publishing"
+            exit 0
+          fi
+          
+          echo "exists=false" >> $GITHUB_OUTPUT
+          echo "CPU artifacts do not exist (version ${VERSION}), will publish"
+      - name: Check if GPU artifacts exist
+        id: check_gpu
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set +e  # Don't exit on error
+          VERSION="${{ steps.version.outputs.ort_version }}"
+          OWNER="${{ github.repository_owner }}"
+          # URL-encode the package name (dots become %2E)
+          PACKAGE_NAME="com.jyuzawa.onnxruntime-gpu"
+          PACKAGE_NAME_ENCODED=$(echo "$PACKAGE_NAME" | sed 's/\./%2E/g')
+          
+          echo "Checking for package: ${PACKAGE_NAME} (encoded: ${PACKAGE_NAME_ENCODED}) version: ${VERSION} owner: ${OWNER}"
+          
+          # Try org endpoint first
+          echo "Trying org endpoint..."
+          VERSIONS=$(gh api "/orgs/${OWNER}/packages/maven/${PACKAGE_NAME_ENCODED}/versions" --jq ".[].name" 2>&1)
+          ORG_EXIT_CODE=$?
+          echo "Org endpoint result (exit code ${ORG_EXIT_CODE}): ${VERSIONS}"
+          
+          if [ $ORG_EXIT_CODE -eq 0 ] && echo "$VERSIONS" | grep -qx "${VERSION}"; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "GPU artifacts already exist (version ${VERSION}), will skip publishing"
+            exit 0
+          fi
+          
+          # Try user endpoint
+          echo "Trying user endpoint..."
+          VERSIONS=$(gh api "/users/${OWNER}/packages/maven/${PACKAGE_NAME_ENCODED}/versions" --jq ".[].name" 2>&1)
+          USER_EXIT_CODE=$?
+          echo "User endpoint result (exit code ${USER_EXIT_CODE}): ${VERSIONS}"
+          
+          if [ $USER_EXIT_CODE -eq 0 ] && echo "$VERSIONS" | grep -qx "${VERSION}"; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "GPU artifacts already exist (version ${VERSION}), will skip publishing"
+            exit 0
+          fi
+          
+          echo "exists=false" >> $GITHUB_OUTPUT
+          echo "GPU artifacts do not exist (version ${VERSION}), will publish"
+      - name: Build with Gradle
+        run: |
+          ./gradlew --no-daemon -s :build
+      - name: Publish main library to GitHub Packages
+        run: |
+          ./gradlew --no-daemon -s publishOnnxruntimePublicationToGitHubPackagesRepository -Prepo=${{ github.repository }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
+        continue-on-error: true
+      - name: Publish CPU artifacts to GitHub Packages
+        if: steps.check_cpu.outputs.exists != 'true'
+        run: |
+          ./gradlew --no-daemon -s publishOnnxruntimeCpuPublicationToGitHubPackagesRepository -Prepo=${{ github.repository }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
+      - name: Publish GPU artifacts to GitHub Packages
+        if: steps.check_gpu.outputs.exists != 'true'
+        run: |
+          ./gradlew --no-daemon -s publishOnnxruntimeGpuPublicationToGitHubPackagesRepository -Prepo=${{ github.repository }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}

--- a/build.gradle
+++ b/build.gradle
@@ -258,7 +258,7 @@ def makePom(node, artifactId, osArches, theVersion, theBaseline) {
 }
 
 project.group = "com.jyuzawa"
-def REPO = "yuzawa-san/onnxruntime-java"
+def REPO = project.findProperty("repo") ?: "yuzawa-san/onnxruntime-java"
 
 nexusPublishing {
 	repositories {
@@ -271,42 +271,52 @@ nexusPublishing {
 	}
 }
 
+def configureNativePom = { pom ->
+	pom.name = 'ONNX Runtime for Java'
+	pom.inceptionYear = '2022'
+	pom.description = project.description
+	pom.url = "https://github.com/${REPO}"
+	pom.issueManagement {
+		url = "https://github.com/${REPO}/issues"
+		system = "GitHub Issues"
+	}
+	pom.licenses {
+		license {
+			name = 'MIT License'
+			url = 'https://opensource.org/licenses/MIT'
+			distribution = 'repo'
+		}
+	}
+	pom.developers {
+		developer {
+			id = 'yuzawa-san'
+			name = 'James Yuzawa'
+			email = 'jtyuzawa+onnxruntime-java@gmail.com'
+		}
+	}
+	pom.scm {
+		connection = "scm:git:git://github.com/${REPO}.git"
+		developerConnection = "scm:git:git@github.com:${REPO}.git"
+		url = "https://github.com/${REPO}"
+	}
+}
+
 publishing {
+	repositories {
+		maven {
+			name = "GitHubPackages"
+			url = uri("https://maven.pkg.github.com/${REPO}")
+			credentials {
+				username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_ACTOR")
+				password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
+			}
+		}
+	}
 	publications {
 		onnxruntimeCpu(MavenPublication) {
 			version = ORT_JAR_VERSION
 			artifactId = "${rootProject.name}-cpu"
-			// NOTE: sonatype does not believe in our parent artifact
-			// TODO: DRY
-			pom {
-				name = 'ONNX Runtime for Java'
-				inceptionYear = '2022'
-				description = project.description
-				url = "https://github.com/${REPO}"
-				issueManagement {
-					url = "https://github.com/${REPO}/issues"
-					system = "GitHub Issues"
-				}
-				licenses {
-					license {
-						name = 'MIT License'
-						url = 'https://opensource.org/licenses/MIT'
-						distribution = 'repo'
-					}
-				}
-				developers {
-					developer {
-						id = 'yuzawa-san'
-						name = 'James Yuzawa'
-						email = 'jtyuzawa+onnxruntime-java@gmail.com'
-					}
-				}
-				scm {
-					connection = "scm:git:git://github.com/${REPO}.git"
-					developerConnection = "scm:git:git@github.com:${REPO}.git"
-					url = "https://github.com/${REPO}"
-				}
-			}
+			pom(configureNativePom)
 			pom.withXml {
 				makePom(asNode(), artifactId, cpuOsArches, ORT_JAR_VERSION, ORT_BASELINE)
 			}
@@ -315,10 +325,10 @@ publishing {
 				artifact tasks.named("osArchJar${it}")
 			}
 		}
-		/*
 		onnxruntimeGpu(MavenPublication) {
 			version = ORT_JAR_VERSION
 			artifactId = "${rootProject.name}-gpu"
+			pom(configureNativePom)
 			pom.withXml {
 				makePom(asNode(), artifactId, gpuOsArches, ORT_JAR_VERSION, ORT_BASELINE)
 			}
@@ -327,7 +337,6 @@ publishing {
 				artifact tasks.named("osArchJar${it}")
 			}
 		}
-		*/
 		onnxruntime(MavenPublication) {
 			from components.java
 			pom {
@@ -363,8 +372,15 @@ publishing {
 	}
 }
 
+def isSigningConfigured = project.hasProperty('signing.keyId')
+		|| project.hasProperty('signingKey')
+		|| System.getenv('GPG_PRIVATE_KEY')
+
 signing {
-	sign publishing.publications
+	required { isSigningConfigured }
+	if (isSigningConfigured) {
+		sign publishing.publications
+	}
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 version=2.0.1-SNAPSHOT
+repo=yuzawa-san/onnxruntime-java
 com.jyuzawa.onnxruntime.library_version=1.23.2
 com.jyuzawa.onnxruntime.library_baseline=2.0.0
 org.gradle.parallel=true


### PR DESCRIPTION
# Description of Changes

We have made ourselves a tidbit for publishing snapshots of the runtime. We hope it may be useful for the original repo too.
We also unblocked gpu builds (they are quite necessary for us), but it is up for discussion if relevant parts to the change should be commented out. 

# Test Plan

- Tested in our fork: https://github.com/NeverBlink-OSS/onnxruntime-java