### PR TITLE
Add support for float16 and unsigned types in tensor creation

### DIFF
--- a/src/main/java/com/jyuzawa/onnxruntime/TensorInfoImpl.java
+++ b/src/main/java/com/jyuzawa/onnxruntime/TensorInfoImpl.java
@@ -102,25 +102,16 @@ final class TensorInfoImpl implements TensorInfo {
         return false;
     }
 
-    final OnnxTensorImpl newValue(ValueContext valueContext, MemorySegment ortValueAddress) {
-        switch (type) {
-            case BOOL:
-            case INT8:
-                return new OnnxTensorByteImpl(this, valueContext, ortValueAddress);
-            case INT16:
-                return new OnnxTensorShortImpl(this, valueContext, ortValueAddress);
-            case INT32:
-                return new OnnxTensorIntImpl(this, valueContext, ortValueAddress);
-            case INT64:
-                return new OnnxTensorLongImpl(this, valueContext, ortValueAddress);
-            case FLOAT:
-                return new OnnxTensorFloatImpl(this, valueContext, ortValueAddress);
-            case DOUBLE:
-                return new OnnxTensorDoubleImpl(this, valueContext, ortValueAddress);
-            case STRING:
-                return new OnnxTensorStringImpl(this, valueContext, ortValueAddress);
-            default:
-                throw new UnsupportedOperationException("OnnxTensor with type " + type + " is not supported");
-        }
+    OnnxTensorImpl newValue(ValueContext valueContext, MemorySegment ortValueAddress) {
+        return switch (type) {
+            case BOOL, INT8, UINT8 -> new OnnxTensorByteImpl(this, valueContext, ortValueAddress);
+            case INT16, UINT16 -> new OnnxTensorShortImpl(this, valueContext, ortValueAddress);
+            case INT32, UINT32 -> new OnnxTensorIntImpl(this, valueContext, ortValueAddress);
+            case INT64, UINT64 -> new OnnxTensorLongImpl(this, valueContext, ortValueAddress);
+            case FLOAT, FLOAT16, BFLOAT16 -> new OnnxTensorFloatImpl(this, valueContext, ortValueAddress);
+            case DOUBLE -> new OnnxTensorDoubleImpl(this, valueContext, ortValueAddress);
+            case STRING -> new OnnxTensorStringImpl(this, valueContext, ortValueAddress);
+            default -> throw new UnsupportedOperationException("OnnxTensor with type " + type + " is not supported");
+        };
     }
 }


### PR DESCRIPTION
# Description of Changes

We have implemented support for unsigned integers and float16 types tensors creation from a `newTensor` API. 
It mirrors the ONNX to Java layout for such types found here: https://github.com/microsoft/onnxruntime/blob/main/java/src/main/java/ai/onnxruntime/TensorInfo.java

# Dependencies

None added or modified. 
No dependenices on other issues.

# Issues Fixed

Implements #418

# Test Plan

Currently, no unit tests.