### PR TITLE
eliminate crashes on environment cleanup

### DIFF
--- a/src/main/java/com/jyuzawa/onnxruntime/Environment.java
+++ b/src/main/java/com/jyuzawa/onnxruntime/Environment.java
@@ -12,13 +12,21 @@ import java.util.Map;
  * The environment in which model evaluation sessions can be constructed. Only
  * one environment should be used in your application. This class is thread safe.
  *
+ * The close() method is deprecated.
+ * In general, there should not be a need to close the environment,
+ * given there should be single environment per JVM process and
+ * it can live for the duration of the application.
+ *
  * @since 1.0.0
  */
 public interface Environment extends AutoCloseable {
 
     /**
-     * Releases native resources.
+     * DEPRECATED: This is a no-op.
+     * If you want to close the environment, just set all references to this environment null
+     * and the garbage collector will release it automatically.
      */
+    @Deprecated
     @Override
     void close();
 

--- a/src/main/java/com/jyuzawa/onnxruntime/EnvironmentImpl.java
+++ b/src/main/java/com/jyuzawa/onnxruntime/EnvironmentImpl.java
@@ -18,15 +18,17 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-final class EnvironmentImpl extends ManagedImpl implements Environment {
+final class EnvironmentImpl implements Environment {
 
+    protected final ApiImpl api;
     private final MemorySegment address;
     final MemorySegment memoryInfo;
     final MemorySegment ortAllocator;
     private final ValueContext valueContext;
 
     EnvironmentImpl(Builder builder) {
-        super(builder.api, Arena.ofShared());
+        this.api = builder.api;
+        Arena arena = Arena.ofAuto();
         try (Arena temporarySession = Arena.ofConfined()) {
             MemorySegment options = OrtEnvCreationOptions.allocate(temporarySession);
             OrtEnvCreationOptions.version(options, onnxruntime_all_h.ORT_API_VERSION());
@@ -111,7 +113,6 @@ final class EnvironmentImpl extends ManagedImpl implements Environment {
         }
     }
 
-    @Override
     MemorySegment address() {
         return address;
     }
@@ -242,5 +243,10 @@ final class EnvironmentImpl extends ManagedImpl implements Environment {
     public OnnxTensor newTensor(OnnxTensorElementDataType type, List<Long> shape) {
         TensorInfoImpl tensorInfo = new TensorInfoImpl(type, shape);
         return tensorInfo.newValue(valueContext, null);
+    }
+
+    @Override
+    public void close() {
+        // does not do anything any more
     }
 }

--- a/src/test/java/com/jyuzawa/onnxruntime/ConcurrencyTest.java
+++ b/src/test/java/com/jyuzawa/onnxruntime/ConcurrencyTest.java
@@ -68,7 +68,7 @@ public class ConcurrencyTest {
 
     @AfterAll
     public static void tearDown() {
-        environment.close();
+        environment = null;
     }
 
     @Test

--- a/src/test/java/com/jyuzawa/onnxruntime/SessionTest.java
+++ b/src/test/java/com/jyuzawa/onnxruntime/SessionTest.java
@@ -81,8 +81,12 @@ public class SessionTest {
     }
 
     @AfterAll
-    public static void tearDown() {
-        environment.close();
+    public static void tearDown() throws InterruptedException {
+        environment = null;
+        // check to see if there are any weird issue with the auto free logic
+        Thread.sleep(1000);
+        System.gc();
+        Thread.sleep(1000);
     }
 
     private ByteBuffer identityModel(TypeProto type) {


### PR DESCRIPTION
the unit tests would fail sometimes since the environment was getting closed prior to the release of all of the "automatic" tensors. there was nothing ensuring the order of operations here: that those tensors get released first prior to releasing the environment and its ort allocator. the solution was to make the environment use an automatic arena. any alive tensors or sessions will prevent the environment from getting reaped. 